### PR TITLE
Require proper multicolumn wizard dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "contao/core-bundle": "^4 || ^5",
-        "menatwork/contao-multicolumnwizard": "^3.6"
+        "menatwork/contao-multicolumnwizard-bundle": "^3.6"
     },
 	"require-dev": {
         "contao/manager-plugin": "^2.7"


### PR DESCRIPTION
The package [menatwork/contao-multicolumnwizard](https://packagist.org/packages/menatwork/contao-multicolumnwizard) is abandoned and does not work with Contao 5

you need to use [menatwork/contao-multicolumnwizard-bundle](https://packagist.org/packages/menatwork/contao-multicolumnwizard-bundle) now